### PR TITLE
Reduce image size with multistage builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
   - docker build --build-arg BUILD_COMMIT=$TRAVIS_COMMIT --target production -t humanconnection/nitro-backend:latest .
-  - docker-compose -f docker-compose.yml up -d
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up -d
 
 script:
   - docker-compose exec backend yarn run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - docker build --build-arg BUILD_COMMIT=$TRAVIS_COMMIT -t humanconnection/nitro-backend:latest .
+  - docker build --build-arg BUILD_COMMIT=$TRAVIS_COMMIT --target production -t humanconnection/nitro-backend:latest .
   - docker-compose -f docker-compose.yml up -d
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,23 @@
-FROM node:10-alpine as builder
+FROM node:10-alpine as base
 LABEL Description="Backend of the Social Network Human-Connection.org" Vendor="Human Connection gGmbH" Version="0.0.1" Maintainer="Human Connection gGmbH (developer@human-connection.org)"
 
-# Expose the app port
 EXPOSE 4000
-
 ARG BUILD_COMMIT
 ENV BUILD_COMMIT=$BUILD_COMMIT
 ARG WORKDIR=/nitro-backend
 RUN mkdir -p $WORKDIR
 WORKDIR $WORKDIR
-
-# Install the Application Dependencies
-COPY package.json .
-COPY yarn.lock .
-RUN yarn install --frozen-lockfile --non-interactive
-
-COPY . .
+COPY package.json yarn.lock ./
 COPY .env.template .env
-
-RUN yarn run build
 CMD ["yarn", "run", "start"]
 
+FROM base as builder
+RUN yarn install --frozen-lockfile --non-interactive
+COPY . .
+RUN yarn run build
+
 # reduce image size with a multistage build
-FROM node:10-alpine as production
+FROM base as production
 ENV NODE_ENV=production
 COPY --from=builder /nitro-backend/dist ./dist
-COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --non-interactive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:10-alpine
+FROM node:10-alpine as builder
 LABEL Description="Backend of the Social Network Human-Connection.org" Vendor="Human Connection gGmbH" Version="0.0.1" Maintainer="Human Connection gGmbH (developer@human-connection.org)"
 
 # Expose the app port
 EXPOSE 4000
 
+ARG BUILD_COMMIT
+ENV BUILD_COMMIT=$BUILD_COMMIT
 ARG WORKDIR=/nitro-backend
 RUN mkdir -p $WORKDIR
 WORKDIR $WORKDIR
@@ -11,10 +13,17 @@ WORKDIR $WORKDIR
 # Install the Application Dependencies
 COPY package.json .
 COPY yarn.lock .
-RUN yarn install --production=false --frozen-lockfile --non-interactive
+RUN yarn install --frozen-lockfile --non-interactive
 
 COPY . .
 COPY .env.template .env
 
 RUN yarn run build
 CMD ["yarn", "run", "start"]
+
+# reduce image size with a multistage build
+FROM node:10-alpine as production
+ENV NODE_ENV=production
+COPY --from=builder /nitro-backend/dist ./dist
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --non-interactive

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - .:/nitro-backend
       - /nitro-backend/node_modules
+    command: yarn run dev
   neo4j:
     ports:
       - 7687:7687

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,9 @@ version: "3.7"
 
 services:
   backend:
+    build:
+      context: .
+      target: builder
     volumes:
       - .:/nitro-backend
       - /nitro-backend/node_modules

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,7 @@ version: "3.7"
 
 services:
   backend:
+    image: humanconnection/nitro-backend:builder
     build:
       context: .
       target: builder

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  backend:
+    image: humanconnection/nitro-backend:builder
+    build:
+      context: .
+      target: builder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: "3.7"
 services:
   backend:
     image: humanconnection/nitro-backend:latest
-    build: .
+    build:
+      context: .
+      target: production
     networks:
       - hc-network
     depends_on:


### PR DESCRIPTION
We should not include any development depemencies on the production image. Therefore we can utilize the power of docker staged build process. See: https://glebbahmutov.com/blog/making-small-docker-image/

Todo's
- [x] how is it possible to run tests when we do not include dev dependencies? @roschaefer 