### PR TITLE
Fix 'audience must be a string or array'

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,7 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=letmein
 GRAPHQL_PORT=4000
 GRAPHQL_URI=http://localhost:4000
+CLIENT_URI=http://localhost:3000
 MOCK=false
 
 JWT_SECRET=b/&&7b78BF&fv/Vd


### PR DESCRIPTION
I ran into this issue after setting up the installation locally.