### PR TITLE
Don't run tests in /dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   },
   "author": "Human Connection gGmbH",
   "license": "MIT",
+  "jest": {
+    "verbose": true,
+    "testMatch": ["**/src/**/?(*.)+(spec|test).js?(x)" ]
+  },
   "dependencies": {
     "apollo-cache-inmemory": "~1.3.11",
     "apollo-client": "~2.4.8",


### PR DESCRIPTION
If you ran `yarn run build` followed by `yarn run test:jest` it was
running the tests twice, because it matched the `/dist` folder, too.