### PR TITLE
Don't copy private SSH key into docker image

### DIFF
--- a/db-migration-worker/Dockerfile
+++ b/db-migration-worker/Dockerfile
@@ -4,6 +4,5 @@ RUN apt-get update \
  && apt-get -y install --no-install-recommends openssh-client rsync \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-COPY .ssh /root/.ssh/
 COPY import.sh .
 


### PR DESCRIPTION
We can mount the .ssh at runtime. This will allow us to push the docker
image to dockerhub without exposing any secrects.